### PR TITLE
Long URL options

### DIFF
--- a/jquery.oembed.js
+++ b/jquery.oembed.js
@@ -3,8 +3,8 @@
  *
  * Copyright (c) 2009 Richard Chamorro
  * Licensed under the MIT license
- * 
- * Orignal Author: Richard Chamorro 
+ *
+ * Orignal Author: Richard Chamorro
  * Forked by Andrew Mee to Provide a slightly diffent kind of embedding experience
  */
 (function ($) {
@@ -89,7 +89,7 @@
                             error: function () {
                                 settings.onError.call(container, resourceURL)
                             }
-                        }, settings.ajaxOptions || {});
+                        }, settings.longUrlAjaxOptions || settings.ajaxOptions || {});
 
                         $.ajax(ajaxopts);
 
@@ -135,7 +135,8 @@
         onError: function (a, b, c, d) {
             console.log('err:', a, b, c, d)
         },
-        ajaxOptions: {}
+        ajaxOptions: {},
+        longUrlAjaxOptions: {}
     };
 
     /* Private functions */


### PR DESCRIPTION
This adds the ability the configure your own `expand` API. Unfortunately, `longurl.org` isn't available over https, which is causing safety warnings in our production environment. This allows anyone to run their own URL expander.

There are a few more https related issues, but those are tackled by #18