### PR TITLE
Bug-fix for Mixed Content error, when YouTube is embedded in HTTPS...

### DIFF
--- a/jquery.oembed.js
+++ b/jquery.oembed.js
@@ -543,7 +543,7 @@
     $.fn.oembed.providers = [
 
         //Video
-        new $.fn.oembed.OEmbedProvider("youtube", "video", ["youtube\\.com/watch.+v=[\\w-]+&?", "youtu\\.be/[\\w-]+", "youtube.com/embed"], 'http://www.youtube.com/embed/$1?wmode=transparent', {
+        new $.fn.oembed.OEmbedProvider("youtube", "video", ["youtube\\.com/watch.+v=[\\w-]+&?", "youtu\\.be/[\\w-]+", "youtube.com/embed"], '//www.youtube.com/embed/$1?wmode=transparent', {
             templateRegex: /.*(?:v\=|be\/|embed\/)([\w\-]+)&?.*/, embedtag: {tag: 'iframe', width: '425', height: '349'}
         }),
 


### PR DESCRIPTION
... parent page. See issue #26 

In YouTube provider, the end-point URL was hard-coded to the `http` scheme. Solution: Replaced the `http://` URL with `//`, so HTTPS will be used instead, when parent page was loaded via HTTPS. There are many similar URLs in other providers, maybe this solution would work for them, too?