### PR TITLE
Added support for YouTube start and end time video

### DIFF
--- a/jquery.oembed.js
+++ b/jquery.oembed.js
@@ -543,7 +543,7 @@
     $.fn.oembed.providers = [
 
         //Video
-        new $.fn.oembed.OEmbedProvider("youtube", "video", ["youtube\\.com/watch.+v=[\\w-]+&?", "youtu\\.be/[\\w-]+", "youtube.com/embed"], 'http://www.youtube.com/embed/$1?wmode=transparent', {
+        new $.fn.oembed.OEmbedProvider("youtube", "video", ["youtube\\.com/watch.+v=[\\w-]+&?", "youtu\\.be/[\\w-]+", "youtube.com/embed", "youtube\\.com/v/[\\w-]+&?"], 'http://www.youtube.com/embed/$1?wmode=transparent', {
             templateRegex: /.*(?:v\=|be\/|embed\/)([\w\-]+)&?.*/, embedtag: {tag: 'iframe', width: '425', height: '349'}
         }),
 


### PR DESCRIPTION
Added support for following type of URLs
- https://www.youtube.com/v/chElHV99xak
- https://www.youtube.com/v/chElHV99xak?start=53&end=59

Now you can embed videos which specify start and end time and the videos that have been shared as full screen videos.
