### PR TITLE
Add ContentUpgrade.me provider.

### DIFF
--- a/jquery.oembed.js
+++ b/jquery.oembed.js
@@ -696,6 +696,7 @@
         new $.fn.oembed.OEmbedProvider("giflike", "photo", ["giflike\\.com/.+"], "http://www.giflike.com/embed/$1", {templateRegex: [/.*giflike\.com\/embed\/(\w+).*/, /.*giflike\.com\/a\/(\w+).*/], embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
 
         //Rich
+        new $.fn.oembed.OEmbedProvider("contentupgrade", "rich", ["contentupgrade.me/.+"], "https://contentupgrade.me/oembed.json"),
         new $.fn.oembed.OEmbedProvider("twitter", "rich", ["twitter.com/.+"], "https://api.twitter.com/1/statuses/oembed.json"),
         new $.fn.oembed.OEmbedProvider("gmep", "rich", ["gmep.imeducate.com/.*", "gmep.org/.*"], "http://gmep.org/oembed.json"),
         new $.fn.oembed.OEmbedProvider("urtak", "rich", ["urtak.com/(u|clr)/.+"], "http://oembed.urtak.com/1/oembed"),

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "jquery-oembed-all",
+  "version": "0.9.0-rc1",
+  "homepage": "https://github.com/nfl/jquery-oembed-all",
+  "authors": [
+    "National Football League <engineers@nfl.com>"
+  ],
+  "description": "Use native oEmbed services when possible.",
+  "main": "jquery.oembed.js",
+  "license": "MIT",
+  "keywords": [
+    "oembed"
+  ],
+  "ignore": [
+    "examples",
+    "*.md",
+    "CHANGELOG"
+  ],
+  "dependencies": {
+    "jquery": ">=1.4.3"
+  }
+}


### PR DESCRIPTION
This adds integration with ContentUpgrade.me, which allows authors to
include downloadable lead magnets on any page.

It converts links from https://contentupgrade.me/* (e.g.
https://contentupgrade.me/kKpZyJjG) to embedded objects.